### PR TITLE
Unify raw_to_prob helper

### DIFF
--- a/R/psychopdaroc.b.R
+++ b/R/psychopdaroc.b.R
@@ -287,55 +287,6 @@ print.DeLong = function(x, digits = max(3, getOption("digits") - 3), ...) {
   cat(paste("\nOverall test:\n p-value =", format.pval(x$global.p, digits = digits), "\n"))
 }
 
-#' Convert raw test values to predicted probabilities using ROC curve
-#' @param values Raw test values
-#' @param actual Binary outcomes (0/1)
-#' @param direction Direction of the test ">=" or "<="
-#' @return Vector of predicted probabilities
-raw_to_prob <- function(values, actual, direction = ">=") {
-  # Sort values for thresholds
-  sorted_values <- sort(unique(values))
-
-  # Calculate sensitivity and specificity for each threshold
-  threshold_data <- data.frame(
-    threshold = numeric(length(sorted_values)),
-    sensitivity = numeric(length(sorted_values)),
-    specificity = numeric(length(sorted_values))
-  )
-
-  for (i in seq_along(sorted_values)) {
-    threshold <- sorted_values[i]
-
-    if (direction == ">=") {
-      predicted_pos <- values >= threshold
-    } else {
-      predicted_pos <- values <= threshold
-    }
-
-    tp <- sum(predicted_pos & actual == 1)
-    fp <- sum(predicted_pos & actual == 0)
-    tn <- sum(!predicted_pos & actual == 0)
-    fn <- sum(!predicted_pos & actual == 1)
-
-    threshold_data$threshold[i] <- threshold
-    threshold_data$sensitivity[i] <- tp / (tp + fn)
-    threshold_data$specificity[i] <- tn / (tn + fp)
-  }
-
-  # For each value, find nearest threshold and use sensitivity as probability
-  probs <- numeric(length(values))
-  for (i in seq_along(values)) {
-    idx <- which.min(abs(threshold_data$threshold - values[i]))
-    if (direction == ">=") {
-      probs[i] <- threshold_data$sensitivity[idx]
-    } else {
-      probs[i] <- 1 - threshold_data$sensitivity[idx]
-    }
-  }
-
-  return(probs)
-}
-
 
 #' Calculate Integrated Discrimination Improvement (IDI)
 #' @param values_new Raw values from the new test

--- a/R/psychopdaroc_utilities.R
+++ b/R/psychopdaroc_utilities.R
@@ -375,8 +375,8 @@ bootstrapIDI <- function(new_values, ref_values, actual, direction = ">=", n_boo
     boot_idi <- numeric(n_boot)
 
     # Original IDI calculation
-    new_probs <- rawToProb(new_values, actual, direction)
-    ref_probs <- rawToProb(ref_values, actual, direction)
+    new_probs <- raw_to_prob(new_values, actual, direction)
+    ref_probs <- raw_to_prob(ref_values, actual, direction)
 
     original_idi <- (mean(new_probs[actual == 1]) - mean(new_probs[actual == 0])) -
         (mean(ref_probs[actual == 1]) - mean(ref_probs[actual == 0]))
@@ -390,8 +390,8 @@ bootstrapIDI <- function(new_values, ref_values, actual, direction = ">=", n_boo
         boot_actual <- actual[boot_idx]
 
         # Calculate probabilities for bootstrap sample
-        boot_new_probs <- rawToProb(boot_new, boot_actual, direction)
-        boot_ref_probs <- rawToProb(boot_ref, boot_actual, direction)
+        boot_new_probs <- raw_to_prob(boot_new, boot_actual, direction)
+        boot_ref_probs <- raw_to_prob(boot_ref, boot_actual, direction)
 
         # Calculate IDI
         boot_idi[i] <- (mean(boot_new_probs[boot_actual == 1]) - mean(boot_new_probs[boot_actual == 0])) -
@@ -484,7 +484,7 @@ bootstrapNRI <- function(new_values, ref_values, actual, direction = ">=",
 #' @param actual Binary outcomes (0/1)
 #' @param direction Direction of test (">=", "<=")
 #' @return Vector of predicted probabilities
-rawToProb <- function(values, actual, direction = ">=") {
+raw_to_prob <- function(values, actual, direction = ">=") {
 
     # Get unique sorted values for thresholds
     sorted_values <- sort(unique(values))
@@ -531,8 +531,8 @@ rawToProb <- function(values, actual, direction = ">=") {
 computeNRI <- function(new_values, ref_values, actual, direction = ">=", thresholds = NULL) {
 
     # Convert to probabilities
-    new_probs <- rawToProb(new_values, actual, direction)
-    ref_probs <- rawToProb(ref_values, actual, direction)
+    new_probs <- raw_to_prob(new_values, actual, direction)
+    ref_probs <- raw_to_prob(ref_values, actual, direction)
 
     # Identify events and non-events
     events <- actual == 1


### PR DESCRIPTION
## Summary
- centralize `raw_to_prob` in `psychopdaroc_utilities.R`
- remove duplicate function definition from `psychopdaroc.b.R`
- adjust utilities to use the new function name

## Testing
- `R -q -e 'devtools::test()'` *(fails: `R: command not found`)*